### PR TITLE
CSIC-107-file-limit-specified-pool-not-ibox

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -75,6 +75,8 @@ type Client interface {
 	GetTreeq(fileSystemID, treeqID int64) (*Treeq, error)
 	UpdateTreeq(fileSystemID, treeqID int64, body map[string]interface{}) (*Treeq, error)
 	GetTreeqSizeByFileSystemID(filesystemID int64) (int64, error)
+	GetFileSystemCountByPoolID(poolID int64)(int, error)
+	GetTreeqByName(fileSystemID int64,treeqName string) (*Treeq, error)
 }
 
 //ClientService : struct having reference of rest client and will host methods which need rest operations
@@ -133,7 +135,7 @@ func (c *ClientService) AddHostSecurity(chapCreds map[string]string, hostID int)
 			err = errors.New("AddHostPort Panic occured -  " + fmt.Sprint(res))
 		}
 	}()
-	log.Infof("add chap atuhentication for hostID % : ", hostID)
+	log.Infof("add chap atuhentication for hostID %d : ", hostID)
 	uri := "api/rest/hosts/" + strconv.Itoa(hostID) + "?approved=true"
 	resp, err := c.getJSONResponse(http.MethodPut, uri, chapCreds, host)
 	if err != nil {
@@ -155,7 +157,7 @@ func (c *ClientService) AddHostPort(portType, portAddress string, hostID int) (h
 			err = errors.New("AddHostPort Panic occured -  " + fmt.Sprint(res))
 		}
 	}()
-	log.Infof("add port % for hostID % : ", portAddress, hostID)
+	log.Infof("add port %s for hostID %d : ", portAddress, hostID)
 	uri := "api/rest/hosts/" + strconv.Itoa(hostID) + "/ports"
 	body := map[string]interface{}{"address": portAddress, "type": portType}
 	resp, err := c.getJSONResponse(http.MethodPost, uri, body, &hostPort)
@@ -482,7 +484,7 @@ func (c *ClientService) GetAllHosts() (host []Host, err error) {
 		apiresp := resp.(client.ApiResponse)
 		hosts, _ = apiresp.Result.([]Host)
 	}
-	log.Info("found %d hosts ", len(hosts))
+	log.Infof("found %d hosts ", len(hosts))
 	return hosts, nil
 }
 

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -282,7 +282,7 @@ func (suite *ApiTestSuite) Test_MapVolumeToHost_Fail() {
 	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
 
 	// Act
-	_, err := service.MapVolumeToHost(1, 2)
+	_, err := service.MapVolumeToHost(1, 2,2)
 
 	// Assert
 	assert.NotNil(suite.T(), err, "Error should not be nil")
@@ -296,7 +296,7 @@ func (suite *ApiTestSuite) Test_MapVolumeToHost_Success() {
 	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
 
 	// Act
-	response, _ := service.MapVolumeToHost(1001, 2)
+	response, _ := service.MapVolumeToHost(1001, 2,2)
 
 	// Assert
 	assert.NotNil(suite.T(), response, "Response should not be nil")
@@ -411,7 +411,7 @@ func (suite *ApiTestSuite) Test_GetFilesytemTreeqCount_error() {
 }
 
 func (suite *ApiTestSuite) Test_GetFilesytemTreeqCount_Success() {
-	expectedResponse := client.ApiResponse{Result: Metadata{ID: 1, ObjectId: 10, Key: "host.k8s.treeqs", Value: "10", ObjectType: "filesystem"}}
+	expectedResponse := client.ApiResponse{MetaData: client.Resultmetadata{NoOfObject:10}}
 	suite.clientMock.On("Get").Return(expectedResponse, nil)
 	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
 	// Act
@@ -423,8 +423,7 @@ func (suite *ApiTestSuite) Test_GetFilesytemTreeqCount_Success() {
 }
 
 func (suite *ApiTestSuite) Test_GetFilesytemTreeqCount_panic() {
-	expectedResponse := client.ApiResponse{}
-	suite.clientMock.On("Get").Return(expectedResponse, nil)
+	suite.clientMock.On("Get").Return(nil, nil)
 	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
 	// Act
 	_, err := service.GetFilesytemTreeqCount(1001)
@@ -768,11 +767,45 @@ func (suite *ApiTestSuite) Test_UpdateTreeq_fail() {
 
 }
 
+
+func (suite *ApiTestSuite) Test_GetFileSystemCountByPoolID_success() {
+	expectedResponse := client.ApiResponse{Result: getFilesystemArry(), MetaData: client.Resultmetadata{NoOfObject:100}}
+	suite.clientMock.On("Get").Return(expectedResponse, nil)
+	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
+	// Act
+	var poolID int64 = 1
+	response, err := service.GetFileSystemCountByPoolID(poolID)
+	// Assert
+	assert.Nil(suite.T(), err, "Response should not be nil")
+	assert.Equal(suite.T(), 100, response, "response should be nil")
+}
+
+func (suite *ApiTestSuite) Test_GetFileSystemCountByPoolID_Error() {
+	expectedErr := errors.New("some error")
+	suite.clientMock.On("Get").Return(nil,expectedErr)
+	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
+	// Act
+	var poolID int64 = 1
+	_, err := service.GetFileSystemCountByPoolID(poolID)
+	// Assert
+	assert.NotNil(suite.T(), err, "Response should not be nil")	
+}
+func (suite *ApiTestSuite) Test_GetFileSystemCountByPoolID_Panic() {
+	suite.clientMock.On("Get").Return(nil, nil)
+	service := ClientService{api: suite.clientMock, SecretsMap: setSecret()}
+	// Act
+	var poolID int64 = 1
+	_, err := service.GetFileSystemCountByPoolID(poolID)
+	// Assert
+	assert.NotNil(suite.T(), err, "Response should not be nil")	
+}
+
+
 func setSecret() map[string]string {
 	secretMap := make(map[string]string)
 	secretMap["username"] = "admin"
 	secretMap["password"] = "123456"
-	secretMap["hosturl"] = "https://172.17.35.61/"
+	secretMap["hostname"] = "https://172.17.35.61/"
 	return secretMap
 }
 

--- a/api/nfsapiclient.go
+++ b/api/nfsapiclient.go
@@ -736,3 +736,29 @@ func (c *ClientService) GetSnapshotByName(snapshotName string) (*[]FileSystemSna
 	log.Info("Got snapshot : ", snapshotName)
 	return &snapshot, nil
 }
+
+
+// GetFileSystemCountByPoolID :
+func (c *ClientService) GetFileSystemCountByPoolID(poolID int64)(fileSysCnt int, err error){
+	defer func() {
+		if res := recover(); res != nil && err == nil {
+			err = errors.New("GetFileSystemCount Panic occured -  " + fmt.Sprint(res))
+		}
+	}()
+	log.Info("Get FileSystem Count")
+	uri := "api/rest/filesystems?pool_id=" +  strconv.FormatInt(poolID, 10)
+	filesystems := []FileSystem{}
+	resp, err := c.getJSONResponse(http.MethodGet, uri, nil, &filesystems)
+	if err != nil {
+		log.Errorf("error occured while fetching filesystems : %s ", err)
+		return 
+	}
+	apiresp := resp.(client.ApiResponse)
+	metadata := apiresp.MetaData
+	if len(filesystems) == 0 {
+		filesystems, _ = apiresp.Result.([]FileSystem)
+	}	
+	log.Info("Total number of filesystem : ", metadata.NoOfObject)
+	fileSysCnt = metadata.NoOfObject
+	return 
+}

--- a/service/controller.go
+++ b/service/controller.go
@@ -38,7 +38,6 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		return
 	}
 	csiResp, err = storageController.CreateVolume(ctx, req)
-	log.Infof("CreateVolume return  %v", err)
 	if err != nil {
 		err = errors.New("fail to create volume of storage protocol " + storageprotocol)
 		return

--- a/service/controller.go
+++ b/service/controller.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"infinibox-csi-driver/storage"
-
+	
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -24,7 +24,6 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 	configparams["nodeid"] = s.nodeID
 	configparams["driverversion"] = s.driverVersion
 
-	log.Errorf("----------------->>>> %v", configparams)
 	storageprotocol := req.GetParameters()["storage_protocol"]
 
 	log.Infof("In CreateVolume method nodeid: %s, storageprotocols %s", s.nodeID, storageprotocol)
@@ -37,6 +36,7 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		err = errors.New("fail to initialise storage controller while create volume " + storageprotocol)
 		return
 	}
+		
 	csiResp, err = storageController.CreateVolume(ctx, req)
 	if err != nil {
 		err = errors.New("fail to create volume of storage protocol " + storageprotocol)
@@ -81,6 +81,7 @@ func (s *service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 		return
 	}
 	req.VolumeId = volproto.VolumeID
+	
 	deleteResponce, err = storageController.DeleteVolume(ctx, req)
 	if err != nil {
 		log.Errorf("fail to delete volume %v", err)

--- a/service/service.go
+++ b/service/service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/rexray/gocsi"
@@ -56,7 +57,7 @@ func New(configParam map[string]string) Service {
 		hostclustername:     configParam["hostclustername"],
 		driverVersion:       configParam["driverversion"],
 		storagePoolIDToName: map[int64]string{},
-		apiclient:           &api.ClientService{},
+		apiclient:           &api.ClientService{},		
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"os/exec"
 	"strings"
-	"sync"
+	//"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/rexray/gocsi"

--- a/storage/storageservice.go
+++ b/storage/storageservice.go
@@ -73,7 +73,7 @@ type commonservice struct {
 }
 
 //NewStorageController : To return specific implementation of storage
-func NewStorageController(storageProtocol string, configparams ...map[string]string) (storageoperations, error) {
+func NewStorageController(storageProtocol string,configparams ...map[string]string) (storageoperations, error) {
 	comnserv, err := buildCommonService(configparams[0], configparams[1])
 	if err == nil {
 		storageProtocol = strings.TrimSpace(storageProtocol)

--- a/storage/treeqcontroller.go
+++ b/storage/treeqcontroller.go
@@ -13,6 +13,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+
+
+
 func (treeq *treeqstorage) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (csiResp *csi.CreateVolumeResponse, err error) {
 	var treeqVolumeMap map[string]string
 	config := req.GetParameters()
@@ -31,8 +34,10 @@ func (treeq *treeqstorage) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		capacity = gib
 		log.Warn("Volume Minimum capacity should be greater 1 GB")
 	}
-
-	treeqVolumeMap, err = treeq.filesysService.CreateTreeqVolume(config, capacity, pvName)
+	treeqVolumeMap, err=treeq.filesysService.IsTreeqAlreadyExist(config["pool_name"],strings.Trim(config["network_space"],""),pvName)
+	if 	len(treeqVolumeMap)==0 && err==nil {		
+		treeqVolumeMap, err = treeq.filesysService.CreateTreeqVolume(config, capacity, pvName)	
+	}	
 	if err != nil {
 		log.Errorf("fail to create volume %v", err)
 		return &csi.CreateVolumeResponse{}, err


### PR DESCRIPTION
PR Changes:
CSIC-107
	NFS-treeq: should limit amount of file systems within a specified pool, not IBox
CSIC-108
	NFS-treeq: fail to provision a PV if metadata is not available	
CSIC-115	
	NFS-treeq scalability: not all treeqs get deleted
CSIC-112
NFS-treeq: PVs creation at scale doesn't work
