### PR TITLE
Optional node.session.auth credentials

### DIFF
--- a/deploy/helm/infinibox-csi-driver/templates/secret-infinibox.yaml
+++ b/deploy/helm/infinibox-csi-driver/templates/secret-infinibox.yaml
@@ -29,9 +29,17 @@ data:
   {{ else }}
   username: {{ required "hostname is required!" .hostname }}
   {{- end }}
+  {{- if not (empty .inbound_user) }}
   node.session.auth.username: "{{ .inbound_user | b64enc }}"
+  {{- end }}
+  {{- if not (empty .inbound_secret) }}
   node.session.auth.password: "{{ .inbound_secret | b64enc }}"
+  {{- end }}
+  {{- if not (empty .outbound_user) }}
   node.session.auth.username_in: "{{ .outbound_user | b64enc }}"
+  {{- end }}
+  {{- if not (empty .outbound_secret) }}
   node.session.auth.password_in: "{{ .outbound_secret | b64enc }}"
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
node.session.auth params are not mandatory. If not defined in Infinibox_Cred list of maps, the helm chart rendering fails.