### PR TITLE
Add pagination support to GetAllHosts function

### DIFF
--- a/iboxapi/host.go
+++ b/iboxapi/host.go
@@ -142,41 +142,58 @@ type MapVolumeToHostResponse struct {
 	Error    Error    `json:"error"`
 }
 
-func (iboxClient *IboxClient) GetAllHosts() (host []Host, err error) {
+func (iboxClient *IboxClient) GetAllHosts() (hosts []Host, err error) {
 	const FN = "GetAllHosts"
 	url := fmt.Sprintf("%s%s", iboxClient.Creds.Url, "api/rest/hosts")
 	iboxClient.Log.V(TRACE_LEVEL).Info(FN, "URL", url)
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return host, fmt.Errorf("%s - NewRequest - error %w", FN, err)
-	}
-	SetAuthHeader(req, iboxClient.Creds)
+	pageSize := common.IBOX_DEFAULT_QUERY_PAGE_SIZE
+	totalPages := 1 // start with 1, update after first query.
 
-	resp, err := iboxClient.HttpClient.Do(req)
-	if err != nil {
-		return host, fmt.Errorf("%s - Do - error %w", FN, err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			iboxClient.Log.V(INFO_LEVEL).Error(err, FN, "error in Close()", err.Error())
+	for page := 1; page <= totalPages; page++ {
+		iboxClient.Log.V(TRACE_LEVEL).Info(FN, "page", page, "totalPages", totalPages)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return hosts, fmt.Errorf("%s - NewRequest - error %w", FN, err)
 		}
-	}()
+		values := req.URL.Query()
+		values.Add(PARAMETER_PAGE_SIZE, strconv.Itoa(pageSize))
+		values.Add(PARAMETER_PAGE, strconv.Itoa(page))
+		req.URL.RawQuery = values.Encode()
+		iboxClient.Log.V(TRACE_LEVEL).Info(FN, "page", page, "totalPages", totalPages, "URL", req.URL.RawQuery)
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return host, fmt.Errorf("%s - ReadAll - error %w", FN, err)
-	}
-	var responseObject HostResponse
-	err = json.Unmarshal(bodyBytes, &responseObject)
-	if err != nil {
-		return host, fmt.Errorf("%s - Unmarshal - error %w", FN, err)
-	}
-	if responseObject.Error.Code != "" {
-		return host, fmt.Errorf("%s - ibox API - error code: %s message: %s", FN, responseObject.Error.Code, responseObject.Error.Message)
+		SetAuthHeader(req, iboxClient.Creds)
+
+		resp, err := iboxClient.HttpClient.Do(req)
+		if err != nil {
+			return hosts, fmt.Errorf("%s - Do - error %w", FN, err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				iboxClient.Log.V(INFO_LEVEL).Error(err, FN, "error in Close()", err.Error())
+			}
+		}()
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return hosts, fmt.Errorf("%s - ReadAll - error %w", FN, err)
+		}
+		var responseObject HostResponse
+		err = json.Unmarshal(bodyBytes, &responseObject)
+		if err != nil {
+			return hosts, fmt.Errorf("%s - Unmarshal - error %w", FN, err)
+		}
+		if responseObject.Error.Code != "" {
+			return hosts, fmt.Errorf("%s - ibox API - error code: %s message: %s", FN, responseObject.Error.Code, responseObject.Error.Message)
+		}
+
+		hosts = append(hosts, responseObject.Result...)
+
+		if page == 1 {
+			totalPages = responseObject.Metadata.PagesTotal
+		}
 	}
 
-	return responseObject.Result, nil
+	return hosts, nil
 }
 
 func (iboxClient *IboxClient) GetHostByName(hostName string) (host *Host, err error) {


### PR DESCRIPTION
## Summary
This PR adds pagination support to the `GetAllHosts` function in the iboxapi package.

## Problem
Previously, `GetAllHosts` would fetch all hosts in a single API call without pagination, which could cause issues with large numbers of hosts such as:
- API timeouts
- Memory issues
- Poor performance

## Solution
Added pagination support to `GetAllHosts` following the same pattern used in other functions like `GetAllLunByHost` and `GetLunByHostVolume`:
- Uses `common.IBOX_DEFAULT_QUERY_PAGE_SIZE` for page size
- Iterates through all pages using the metadata from the API response
- Appends results from each page to the result slice

## Testing
- Code follows the same pattern as existing paginated functions
- No functional changes to the API contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)